### PR TITLE
Minimal fix illustrating how to avoid Dart LateInitializationError

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,8 +8,9 @@ const String _appId = 'coffeely-app-1-iuuyu';
 final AppConfiguration _appConfig = AppConfiguration(_appId);
 final App app = App(_appConfig);
 
-void main() {
+Future<void> main() async {
   final ItemService service = ItemService();
+  await service.init;
   runApp(MyApp(
     service: service,
   ));

--- a/lib/services/item_service.dart
+++ b/lib/services/item_service.dart
@@ -11,9 +11,11 @@ class ItemService {
   //Realm? _realm;
   //final _realm;
 
+  /// You must await this future to ensure ItemService is ready to use
+  /// before calling any of its methods.
+  late final Future<void> init;
   ItemService() {
-    openRealm();
-    //loginRealm(app, 'leozeferino@gmail.com', '12345678');
+    init = openRealm();
   }
 
   /* Future<User> loginRealm(App app, String email, String password) async {
@@ -29,7 +31,7 @@ class ItemService {
     return currentUser;
   }*/
 
-  openRealm() async {
+  Future<void> openRealm() async {
     var emailCred =
         Credentials.emailPassword('leozeferino@gmail.com', '12345678');
     try {

--- a/lib/services/item_service.dart
+++ b/lib/services/item_service.dart
@@ -35,7 +35,7 @@ class ItemService {
     var emailCred =
         Credentials.emailPassword('leozeferino@gmail.com', '12345678');
     try {
-      User currentUser = await app.logIn(emailCred);
+      User currentUser = app.currentUser ?? await app.logIn(emailCred);
 
       _realm = Realm(
         Configuration.flexibleSync(


### PR DESCRIPTION
Here is a way to avoid the issue described [here](https://www.mongodb.com/community/forums/t/retriving-app-currentuser-to-open-realm-connection-in-another-file-flutter/195955). 

I have also refactored the login a bit, so that the code only logs in if there is no current user. With realm the current user is persisted, so there is no reason to log in on every restart.